### PR TITLE
rename repository to kubeaddons-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kubeaddons-enterprise-tests
+# kubeaddons-tests
 
 This repository hosts tests for the `github.com/mesosphere/kubeaddons-enterprise` repository. 
 
@@ -9,7 +9,7 @@ This repository hosts tests for the `github.com/mesosphere/kubeaddons-enterprise
 ## Testing from kubeaddons-enterprise
 
 - Clone this repo inside the kubeaddons-enterprise
-- Run kubeaddons-enterprise-tests/run-tests.sh
+- Run kubeaddons-tests/run-tests.sh
 
 
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,8 +11,8 @@ if [ -d "./addons" ]
 then
   printf "Running inside the kubeaddons-enterprise repository"
   KUBEADDONS_ENTERPRISE_PATH="."
-  KUBEADDONS_ENTERPRISE_TESTS_PATH="kubeaddons-enterprise-tests/tests/kubeaddons-enterprise"
-  KUTTL_TEST_CONFIGURATION_PATH="kubeaddons-enterprise-tests/kuttl-test.yaml"
+  KUBEADDONS_ENTERPRISE_TESTS_PATH="kubeaddons-tests/tests/kubeaddons-enterprise"
+  KUTTL_TEST_CONFIGURATION_PATH="kubeaddons-tests/kuttl-test.yaml"
 elif [ -d "$KUBEADDONS_ENTERPRISE_PATH" ]
 then
   git -C "${KUBEADDONS_ENTERPRISE_PATH}" checkout ${TESTING_BRANCH}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Addon Tests
 
-kubeaddons-enterprise-tests use KUTTL for testing.
+kubeaddons-tests use KUTTL for testing.
 
 ### Tests structure
 


### PR DESCRIPTION
the repository is renamed from `kubeaddons-enterprise-tests` to `kubeaddons-tests` 

This PR updates in the repository the references `kubeaddons-enterprise-tests`

Signed-off-by: Zain Malik <zmalikshxil@gmail.com>