### PR TITLE
chore: adds Docker hub authentication for kinds containerd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,10 @@ install-bin: bin/kind bin/kubectl-kuttl
 create-kind-cluster: $(KUBEADDONS_TEST_KUBECONFIG)
 
 $(KUBEADDONS_TEST_KUBECONFIG): install-bin
-	KUBECONFIG=$(KUBEADDONS_TEST_KUBECONFIG) bin/kind create cluster --wait 10s --image=kindest/node:v$(KUBERNETES_VERSION)
+		@export KIND_TMP=$(shell mktemp -d) && \
+		sed -e s/DOCKER_USERNAME/"$(DOCKERHUB_ROBOT_USERNAME)"/ -e s/DOCKER_PASSWORD/"$(DOCKERHUB_ROBOT_TOKEN)"/ hack/kind-config.yaml > $${KIND_TMP}/kind-config.yaml && \
+		KUBECONFIG=$(KUBEADDONS_TEST_KUBECONFIG) bin/kind create cluster --wait 10s --image=kindest/node:v$(KUBERNETES_VERSION) --config $${KIND_TMP}/kind-config.yaml
+		rm -rf $${KIND_TMP} ;
 
 .PHONY: kind-test
 kind-test: create-kind-cluster

--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -1,0 +1,14 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
+            username = "DOCKER_USERNAME"
+            password = "DOCKER_PASSWORD"
+            auth = ""
+            identitytoken = ""


### PR DESCRIPTION
https://jira.d2iq.com/browse/D2IQ-73398

By adding docker hub authentication we avoid running into rather tight, anonymous pull request rate limits.
We will need to add `DOCKERHUB_ROBOT_`-credentials to the build job/s in question for this test setup addition to become effective.