### PR TITLE
fix: use absolute path to files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ create-kind-cluster: $(KUBEADDONS_TEST_KUBECONFIG)
 
 $(KUBEADDONS_TEST_KUBECONFIG): install-bin
 		@export KIND_TMP=$(shell mktemp -d) && \
-		sed -e s/DOCKER_USERNAME/"$(DOCKERHUB_ROBOT_USERNAME)"/ -e s/DOCKER_PASSWORD/"$(DOCKERHUB_ROBOT_TOKEN)"/ hack/kind-config.yaml > $${KIND_TMP}/kind-config.yaml && \
+		sed -e s/DOCKER_USERNAME/"$(DOCKERHUB_ROBOT_USERNAME)"/ -e s/DOCKER_PASSWORD/"$(DOCKERHUB_ROBOT_TOKEN)"/ $(ROOT_DIR)/hack/kind-config.yaml > $${KIND_TMP}/kind-config.yaml && \
 		KUBECONFIG=$(KUBEADDONS_TEST_KUBECONFIG) bin/kind create cluster --wait 10s --image=kindest/node:v$(KUBERNETES_VERSION) --config $${KIND_TMP}/kind-config.yaml
 		rm -rf $${KIND_TMP} ;
 


### PR DESCRIPTION
When included in Makefiles for the kubeaddons-enterprise and
kubernetes-base-addons repos, this fails as $PWD/hack/kind-config.yaml
does not exist. This uses the ROOT_PATH variable that allows that file
to be found.