### PR TITLE
test: Use kuttl.dev group instead of depracated kudo.dev

### DIFF
--- a/tests/kubeaddons-enterprise/kuttl-test.yaml
+++ b/tests/kubeaddons-enterprise/kuttl-test.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kudo.dev/v1alpha1
+apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 commands:
   - command: docker cp kind-control-plane:/etc/kubernetes/pki/ca.crt /tmp/ca.crt

--- a/tests/kubernetes-base-addons/kuttl-test.yaml
+++ b/tests/kubernetes-base-addons/kuttl-test.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kudo.dev/v1alpha1
+apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 commands:
   - command: docker cp kind-control-plane:/etc/kubernetes/pki/ca.crt /tmp/ca.crt


### PR DESCRIPTION
As we have bumped KUTTL to `0.8.0`, we often see the warning
```
WARNING: kudo.dev group has been deprecated and is scheduled to be removed in KUTTL 0.8.0
```
This PR updates the `kudo.dev` group used in the TestSuite to `kuttl.dev` to clear the above warning.