### PR TITLE
Update to latest zookeeper.

### DIFF
--- a/tests/kubeaddons-enterprise/addons/zookeeper/0.x/zk-install-0-x/00-install.yaml
+++ b/tests/kubeaddons-enterprise/addons/zookeeper/0.x/zk-install-0-x/00-install.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl apply -f ${KUBEADDONS_ABS_PATH}/addons/zookeeper/0.x/zookeeper-3.yaml
+  - command: kubectl apply -f ${KUBEADDONS_ABS_PATH}/addons/zookeeper/0.x/zookeeper-6.yaml
     namespaced: true


### PR DESCRIPTION
Add tests for the latest version of Zookeeper, to be used in-conjunction with the kubeaddons-enterprise [#133](https://github.com/mesosphere/kubeaddons-enterprise/pull/133)